### PR TITLE
Add support for Jupyter slides

### DIFF
--- a/src/ot2rec_report/main.py
+++ b/src/ot2rec_report/main.py
@@ -43,6 +43,9 @@ def main():
     parser.add_argument("--to_html",
                       help="Export report to html",
                       action="store_true")
+    parser.add_argument("--to_slides",
+                      help="Export report as Jupyter Slides",
+                      action="store_true")
 
     args = parser.parse_args()
 
@@ -88,7 +91,6 @@ def main():
     if args.to_html:
         cmd = [
             "jupyter-nbconvert",
-            "--execute",
             "--to", "html",
             "--TemplateExporter.exclude_input=True",
             "./report.ipynb"]
@@ -98,6 +100,30 @@ def main():
                              stderr=subprocess.STDOUT,
                              encoding="ascii",
                              check=True)
+
+        try:
+            assert(not exp.stderr)
+        except:
+            print(exp.stderr)
+    
+    # Export slides
+    if args.to_slides:
+        cmd = [
+            "jupyter-nbconvert",
+            "./report.ipynb",
+            "--to", "slides",
+            "--TemplateExporter.exclude_input=True",
+            "--SlidesExporter.reveal_theme=simple",
+            "--SlidesExporter.reveal_scroll=True"
+        ]
+
+        exp = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="ascii",
+            check=True
+        )
 
         try:
             assert(not exp.stderr)

--- a/src/ot2rec_report/templates/report_aretomo_align.ipynb
+++ b/src/ot2rec_report/templates/report_aretomo_align.ipynb
@@ -1,27 +1,12 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def printmd(string):\n",
-    "    display(Markdown(string))"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### AreTomo Alignment"
    ]
@@ -29,22 +14,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import seaborn as sns\n",
-    "import matplotlib as mpl\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import yaml"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "aretomo_md_file = f\"{proj_name}_aretomo_mdout.yaml\"\n",
@@ -59,7 +34,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def get_stats(file_in):\n",
@@ -76,7 +55,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "mean_list = []\n",
@@ -90,22 +77,23 @@
     "at_df = pd.DataFrame(columns=[\"Tilt series\", \"Mean shift (px)\", \"Shift s.d. (px)\"])\n",
     "at_df[\"Tilt series\"] = ts_list\n",
     "at_df[\"Mean shift (px)\"] = mean_list\n",
-    "at_df[\"Shift s.d. (px)\"] = std_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "at_df[\"Shift s.d. (px)\"] = std_list\n",
+    "\n",
     "at_df"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "plt.figure(figsize=(15,5))\n",
@@ -125,7 +113,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.10 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -139,7 +127,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a"
+   }
   }
  },
  "nbformat": 4,

--- a/src/ot2rec_report/templates/report_aretomo_header.ipynb
+++ b/src/ot2rec_report/templates/report_aretomo_header.ipynb
@@ -5,6 +5,9 @@
    "id": "c215cf75-f26b-4980-9ca8-6fd75ed2eccf",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true,
+    "slideshow": {
+     "slide_type": "slide"
+    },
     "tags": []
    },
    "source": [
@@ -20,7 +23,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.10 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -34,7 +37,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a"
+   }
   }
  },
  "nbformat": 4,

--- a/src/ot2rec_report/templates/report_aretomo_recon.ipynb
+++ b/src/ot2rec_report/templates/report_aretomo_recon.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "dc30f8f7-6f34-420d-8ef8-d11c56698a5c",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Tomographic Reconstruction (AreTomo)"
    ]
@@ -14,7 +18,8 @@
    "id": "e7a30837",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -40,7 +45,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aec1bde9",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def get_aretomo_tomofilenames():\n",
@@ -114,8 +123,12 @@
    "execution_count": null,
    "id": "aa8e6514",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -144,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {

--- a/src/ot2rec_report/templates/report_ctffind.ipynb
+++ b/src/ot2rec_report/templates/report_ctffind.ipynb
@@ -3,28 +3,25 @@
   {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
-    "## CTF (Defocus) estimation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dfc550c2-37dd-401e-84b0-bfbd6f9f0705",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"CTF estimation has been performed using CTFFind4.\\n\")\n",
+    "## CTF (Defocus) estimation\n",
     "\n",
-    "print(\"Please cite:\")\n",
-    "printmd(\"1. Joseph A. Mindell, Nikolaus Grigorieff. \"\n",
-    "        \"Accurate determination of local defocus and specimen tilt in electron microscopy, \"\n",
-    "        \"*Journal of Structural Biology* **142(3)**:334-347 (2003)\\n\"\n",
-    "        \"2. Alexis Rohou, Nikolaus Grigorieff. \"\n",
-    "        \"CTFFIND4: Fast and accurate defocus estimation from electron micrographs, \"\n",
-    "        \"*Journal of Structural Biology* **192(2)**:216-221 (2015)\"\n",
-    "       )"
+    "CTF estimation has been performed using CTFFind4.\n",
+    "\n",
+    "Please cite:\n",
+    "\n",
+    "1. Joseph A. Mindell, Nikolaus Grigorieff.\n",
+    "Accurate determination of local defocus and specimen tilt in electron microscopy,\n",
+    "*Journal of Structural Biology* **142(3)**:334-347 (2003)\n",
+    "\n",
+    "2. Alexis Rohou, Nikolaus Grigorieff.\n",
+    "CTFFIND4: Fast and accurate defocus estimation from electron micrographs,\n",
+    "*Journal of Structural Biology* **192(2)**:216-221 (2015)"
    ]
   },
   {
@@ -33,7 +30,8 @@
    "id": "9b6a7b20",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -57,7 +55,11 @@
   {
    "cell_type": "markdown",
    "id": "c61f8d25",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "### Thon rings\n",
     "\n",
@@ -70,7 +72,8 @@
    "id": "b054349f",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -104,7 +107,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70dbf795",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "def show_thon_rings(thon_rings_dict, ts):\n",
@@ -129,7 +140,11 @@
   {
    "cell_type": "markdown",
    "id": "59f58d0a",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "### CTF Resolution"
    ]
@@ -139,8 +154,12 @@
    "execution_count": null,
    "id": "68ea69e8",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],

--- a/src/ot2rec_report/templates/report_ctfsim.ipynb
+++ b/src/ot2rec_report/templates/report_ctfsim.ipynb
@@ -1,54 +1,27 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "acaedf63-f3d2-4d15-983a-6d36d5e2220b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7719196b-a9be-4687-9e98-44ef29ce76e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def printmd(string):\n",
-    "    display(Markdown(string))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
-    "## CTF simulation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dfc550c2-37dd-401e-84b0-bfbd6f9f0705",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"CTF simulation has been performed using O2R-ctfsim.\\n\")\n",
+    "## CTF simulation\n",
     "\n",
-    "print(\"Please cite:\")\n",
-    "printmd(\"1. Alexis Rohou, Nikolaus Grigorieff. \"\n",
-    "        \"CTFFIND4: Fast and accurate defocus estimation from electron micrographs, \"\n",
-    "        \"*Journal of Structural Biology* **192(2)**:216-221 (2015)\"\n",
-    "       )"
+    "CTF simulation has been performed using O2R-ctfsim.\n",
+    "\n",
+    "1. Alexis Rohou, Nikolaus Grigorieff.\n",
+    "CTFFIND4: Fast and accurate defocus estimation from electron micrographs,\n",
+    "*Journal of Structural Biology* **192(2)**:216-221 (2015)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.10 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -62,7 +35,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a"
+   }
   }
  },
  "nbformat": 4,

--- a/src/ot2rec_report/templates/report_imod_align.ipynb
+++ b/src/ot2rec_report/templates/report_imod_align.ipynb
@@ -1,51 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "acaedf63-f3d2-4d15-983a-6d36d5e2220b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "7719196b-a9be-4687-9e98-44ef29ce76e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def printmd(string):\n",
-    "    display(Markdown(string))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Tilt-series Alignment (IMOD)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "9dc0a246-4dea-4ea9-b044-63a22d1461f9",
-   "metadata": {
-    "tags": [
-     "raises-exception"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "import seaborn as sns\n",
-    "import matplotlib as mpl\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import yaml"
    ]
   },
   {
@@ -53,8 +17,13 @@
    "execution_count": null,
    "id": "bc4ff842-5eef-456e-b7d3-23948e016dd5",
    "metadata": {
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -65,21 +34,9 @@
     "    stats = yaml.load(f.read(), Loader=yaml.FullLoader)\n",
     "    \n",
     "stats_df = pd.DataFrame.from_dict(stats).drop(columns=[\"index\"])\n",
-    "stats_df[\"Tilt series\"] = stats_df[\"Tilt series\"].astype(int, copy=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "46811bff-05b3-41b1-be85-96010fc8e914",
-   "metadata": {
-    "tags": [
-     "raises-exception"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "print(stats_df)"
+    "stats_df[\"Tilt series\"] = stats_df[\"Tilt series\"].astype(int, copy=False)\n",
+    "# pd.set_option(\"display.max_rows\", None)\n",
+    "display(stats_df)"
    ]
   },
   {
@@ -87,8 +44,12 @@
    "execution_count": null,
    "id": "f7fa41eb-6f29-4460-ae65-53bbe839eff1",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -111,7 +72,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -125,7 +86,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {

--- a/src/ot2rec_report/templates/report_imod_header.ipynb
+++ b/src/ot2rec_report/templates/report_imod_header.ipynb
@@ -1,51 +1,27 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "acaedf63-f3d2-4d15-983a-6d36d5e2220b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7719196b-a9be-4687-9e98-44ef29ce76e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def printmd(string):\n",
-    "    display(Markdown(string))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
-    "## IMOD (general)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dfc550c2-37dd-401e-84b0-bfbd6f9f0705",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"IMOD has been used in this image processing operation.\\n\")\n",
+    "## IMOD (general)\n",
     "\n",
-    "print(\"Please cite:\")\n",
-    "printmd(\"1. James R. Kremer, David N. Mastronarde, J.Richard McIntosh. \"\n",
-    "        \"Computer Visualization of Three-Dimensional Image Data Using IMOD, \"\n",
-    "        \"*Journal of Structural Biology* **116(1)**:71-76 (1996)\\n\"\n",
-    "        \"2. Mastronarde DN, Held SR. \"\n",
-    "        \"Automated tilt series alignment and tomographic reconstruction in IMOD, \"\n",
-    "        \"*Journal of Structural Biology* **197(2)**:102-113 (2017)\"\n",
-    "        )"
+    "IMOD has been used in this image processing operation.\n",
+    "\n",
+    "Please cite:\n",
+    "\n",
+    "1. James R. Kremer, David N. Mastronarde, J.Richard McIntosh.\n",
+    "Computer Visualization of Three-Dimensional Image Data Using IMOD,\n",
+    "*Journal of Structural Biology* **116(1)**:71-76 (1996)\n",
+    "\n",
+    "2. Mastronarde DN, Held SR.\n",
+    "Automated tilt series alignment and tomographic reconstruction in IMOD,\n",
+    "*Journal of Structural Biology* **197(2)**:102-113 (2017)"
    ]
   }
  ],

--- a/src/ot2rec_report/templates/report_imod_recon.ipynb
+++ b/src/ot2rec_report/templates/report_imod_recon.ipynb
@@ -1,30 +1,13 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "acaedf63-f3d2-4d15-983a-6d36d5e2220b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Markdown, display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7719196b-a9be-4687-9e98-44ef29ce76e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def printmd(string):\n",
-    "    display(Markdown(string))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Tomographic Reconstruction (IMOD)\n",
     "\n",
@@ -41,7 +24,8 @@
    "id": "f77a586f",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -67,7 +51,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6d1a9c1a",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def get_central_slices(img_data):\n",
@@ -127,7 +115,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "521d9b57",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "# Show thumbnails of the tomograms\n",

--- a/src/ot2rec_report/templates/report_main.ipynb
+++ b/src/ot2rec_report/templates/report_main.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "8fc52552-81be-46f3-9552-d461277e6922",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "# Ot2Rec"
    ]
@@ -14,7 +18,8 @@
    "id": "54566ba5",
    "metadata": {
     "tags": [
-     "parameters"
+     "parameters",
+     "hide"
     ]
    },
    "outputs": [],
@@ -28,7 +33,8 @@
    "id": "c3a273d6",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -52,7 +58,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65ff6bf4",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def printmd(string):\n",
@@ -65,7 +75,8 @@
    "id": "fcdac30a-fc45-4b07-ae15-c98739529fdb",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],

--- a/src/ot2rec_report/templates/report_mc.ipynb
+++ b/src/ot2rec_report/templates/report_mc.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "## Motion correction\n",
     "\n",
@@ -18,7 +22,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f4e9036d",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def read_patch_frame_into_df(patch_frame_fname):\n",
@@ -90,14 +98,19 @@
    "execution_count": null,
    "id": "b75a73de",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
    "source": [
     "ts_df = get_ts_log_df(get_tilts_dir())\n",
-    "ts_df.groupby(\"TiltSeries\")[\"EuclideanShift\"].describe()[['mean', 'std', '25%', '50%', '75%']]"
+    "# pd.set_option(\"display.max_rows\", None)\n",
+    "display(ts_df.groupby(\"TiltSeries\")[\"EuclideanShift\"].describe()[['mean', 'std', '25%', '50%', '75%']])"
    ]
   },
   {
@@ -105,8 +118,12 @@
    "execution_count": null,
    "id": "3ee359a4",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],

--- a/src/ot2rec_report/templates/report_rlf_deconv.ipynb
+++ b/src/ot2rec_report/templates/report_rlf_deconv.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "8fc52552-81be-46f3-9552-d461277e6922",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Richardson-Lucy Deconvolution with RedLionFish\n",
     "\n",

--- a/src/ot2rec_report/templates/report_savu_recon.ipynb
+++ b/src/ot2rec_report/templates/report_savu_recon.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "c7f3b12f-45eb-4711-a1f2-2b0b6e126eca",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "## Savu Reconstruction\n",
     "\n",
@@ -32,8 +36,12 @@
    "execution_count": null,
    "id": "cf481c04",
    "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -58,7 +66,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6d22f06b",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def get_central_slices(img_data):\n",
@@ -120,7 +132,8 @@
    "id": "87cc0dde",
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -154,7 +167,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2aaa9e50",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    },
+    "tags": [
+     "hide",
+     "raises_exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "# Show thumbnails of the tomograms\n",

--- a/src/ot2rec_report/templates/workflow_diagram.ipynb
+++ b/src/ot2rec_report/templates/workflow_diagram.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "# Workflow diagram"
    ]
@@ -12,7 +16,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],
@@ -33,7 +38,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "# PROCESSES = [\"motioncor2\", \"ctffind\", \"ctfsim\", \"imod_align\", \"imod_recon\", \"aretomo_recon\", \"savu_recon\", \"rlf_deconv\"]\n",
@@ -43,22 +52,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "outputs": [],
    "source": [
     "def read_ipynb(filename):\n",
     "    fn = pkg_resources.resource_filename(\"RepoTemp.templates\", filename)\n",
     "\n",
     "    with open(fn, 'r') as f:\n",
-    "        return json.load(f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "        return json.load(f)\n",
+    "\n",
     "def get_processes(plist):\n",
     "    node_list = []\n",
     "    for idx, curr_proc in enumerate(plist):\n",
@@ -69,15 +75,8 @@
     "        if file_found:\n",
     "            node_list.append(idx+1)\n",
     "    \n",
-    "    return node_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    return node_list\n",
+    "\n",
     "def create_graph(plist: list):\n",
     "    proc_dict = {\n",
     "        1: \"Motion Corr.\",\n",
@@ -116,17 +115,19 @@
     "        g.add_edge(edge)\n",
     "        \n",
     "    g_plot = Image(g.create_png())\n",
-    "    display(g_plot)\n",
-    "\n",
-    "    "
+    "    display(g_plot)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    },
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "hide"
     ]
    },
    "outputs": [],


### PR DESCRIPTION
Addresses #8 

# Usage

In the terminal in the Ot2Rec processing folder

`o2r.report.run <project_name> --to_slides`

This generates a `report.slides.html` file in the same directory.

