### PR TITLE
Exclude Bad Tilts Section

### DIFF
--- a/src/ot2rec_report/main.py
+++ b/src/ot2rec_report/main.py
@@ -27,6 +27,7 @@ def main():
         "motioncor2": nb_mc,
         "ctffind": nb_ctffind,
         "ctfsim": nb_ctfsim,
+        "exclude_bad_tilts": nb_ebt,
         "imod_header": nb_imod_header,
         "imod_align": nb_imod_align,
         "imod_recon": nb_imod_recon,

--- a/src/ot2rec_report/templates/__init__.py
+++ b/src/ot2rec_report/templates/__init__.py
@@ -5,7 +5,7 @@ from glob import glob
 import ot2rec_report.templates
 
 
-PROCESSES = ["motioncor2", "ctffind", "ctfsim", "imod_align", "imod_recon", "aretomo_align", "aretomo_recon", "savu_recon", "rlf_deconv"]
+PROCESSES = ["motioncor2", "ctffind", "ctfsim", "exclude_bad_tilts", "imod_align", "imod_recon", "aretomo_align", "aretomo_recon", "savu_recon", "rlf_deconv"]
 
 def read_ipynb(filename):
     fn = pkg_resources.resource_filename("ot2rec_report.templates", filename)
@@ -27,3 +27,4 @@ nb_aretomo_align = read_ipynb("report_aretomo_align.ipynb")
 nb_savu_recon = read_ipynb("report_savu_recon.ipynb")
 nb_rlf_deconv = read_ipynb("report_rlf_deconv.ipynb")
 nb_workflow_diagram = read_ipynb("workflow_diagram.ipynb")
+nb_ebt = read_ipynb("report_excludebadtilts.ipynb")

--- a/src/ot2rec_report/templates/report_excludebadtilts.ipynb
+++ b/src/ot2rec_report/templates/report_excludebadtilts.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Excluding bad tilts\n",
+    "\n",
+    "Automatic bad tilt exclusion in Ot2Rec removes tilts if the mean grey value of a tilt is outside of the minimum and maximum accepted percentiles of the overall tilt series grey values.\n",
+    "\n",
+    "Here, the following parameters were applied:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'proj_name' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m ebt_config_yaml \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m{\u001b[39;00mproj_name\u001b[39m}\u001b[39;00m\u001b[39m_exclude_bad_tilts.yaml\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m      3\u001b[0m \u001b[39mif\u001b[39;00m os\u001b[39m.\u001b[39mpath\u001b[39m.\u001b[39misfile(ebt_config_yaml) \u001b[39mis\u001b[39;00m \u001b[39mFalse\u001b[39;00m:\n\u001b[1;32m      4\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mIOError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mExclude bad tilts yaml file \u001b[39m\u001b[39m{\u001b[39;00mebt_config_yaml\u001b[39m}\u001b[39;00m\u001b[39m not found.\u001b[39m\u001b[39m\"\u001b[39m)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'proj_name' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "ebt_config_yaml = f\"{proj_name}_exclude_bad_tilts.yaml\"\n",
+    "\n",
+    "if os.path.isfile(ebt_config_yaml) is False:\n",
+    "    raise IOError(f\"Exclude bad tilts yaml file {ebt_config_yaml} not found.\")\n",
+    "\n",
+    "else:\n",
+    "    with open(ebt_config_yaml, \"r\") as f:\n",
+    "        ebt_config = yaml.load(f, Loader=yaml.FullLoader)\n",
+    "    \n",
+    "    print(f\"Min accepted grey value percentile: {ebt_config['EBT_setup']['min_percentile']}\")\n",
+    "    print(f\"Max accepted grey value percentile: {ebt_config['EBT_setup']['max_percentile']}\")\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The number of tilts excluded for each tilt series are"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ebt_mdout_yaml = f\"{proj_name}_exclude_bad_tilts_mdout.yaml\"\n",
+    "\n",
+    "if os.path.isfile(ebt_mdout_yaml) is False:\n",
+    "    raise IOError(\n",
+    "        f\"Exclude bad tilts mdout yaml file {ebt_mdout_yaml} not found. \"\n",
+    "        \"Was `o2r.excludebadtilts.run` called?\"\n",
+    "    )\n",
+    "\n",
+    "else:\n",
+    "    with open(ebt_mdout_yaml, \"r\") as f:\n",
+    "        ebt_mdout = yaml.load(f, Loader=yaml.FullLoader)\n",
+    "\n",
+    "    excluded_df = pd.DataFrame.from_dict(ebt_mdout)\n",
+    "\n",
+    "# Add number of excluded tilts for each TS to the DF\n",
+    "counts = []\n",
+    "for ts in excluded_df.index:\n",
+    "    counts.append(len(excluded_df.Excluded_Tilt_Index[ts]))\n",
+    "\n",
+    "excluded_df[\"Number_of_Excluded_Tilts\"] = counts\n",
+    "\n",
+    "excluded_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,5))\n",
+    "ax = sns.barplot(\n",
+    "    data=excluded_df,\n",
+    "    x=\"process_list\",\n",
+    "    y=\"Number_of_Excluded_Tilts\",\n",
+    "    color=\"cornflowerblue\"\n",
+    ")\n",
+    "\n",
+    "plt.xlabel(\"Tilt Series\")\n",
+    "\n",
+    "plt.gca().set_ylim(bottom=0)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10 (default, Jun 22 2022, 20:18:18) \n[GCC 9.4.0]"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/ot2rec_report/templates/report_imod_align.ipynb
+++ b/src/ot2rec_report/templates/report_imod_align.ipynb
@@ -32,27 +32,31 @@
    "source": [
     "align_mdout_yaml_file = f\"{proj_name}_align_mdout.yaml\"\n",
     "\n",
-    "with open(align_mdout_yaml_file, \"r\") as f:\n",
-    "    align_md = yaml.load(f.read(), Loader=yaml.FullLoader)\n",
+    "if os.path.isfile(align_mdout_yaml_file) is True:\n",
+    "    with open(align_mdout_yaml_file, \"r\") as f:\n",
+    "        align_md = yaml.load(f.read(), Loader=yaml.FullLoader)\n",
     "\n",
-    "xf_files = {}\n",
-    "for ts in list(align_md[\"stack_output\"].keys()):\n",
-    "    fn = align_md[\"stack_output\"][ts]\n",
-    "    xf_files[ts] = fn.replace(\".st\", \".xf\")\n",
+    "    xf_files = {}\n",
+    "    for ts in list(align_md[\"stack_output\"].keys()):\n",
+    "        fn = align_md[\"stack_output\"][ts]\n",
+    "        xf_files[ts] = fn.replace(\".st\", \".xf\")\n",
     "\n",
-    "eucs = {}\n",
-    "for ts in list(xf_files.keys()):\n",
-    "    with open(xf_files[ts], \"r\") as f:\n",
-    "        lines = f.readlines()\n",
-    "        euc = [(float(l.split()[4])**2 + float(l.split()[5])**2)**0.5 for l in lines]\n",
-    "        eucs[ts] = {}\n",
-    "        eucs[ts][\"Tilt series\"] = align_md[\"ts\"][ts]\n",
-    "        eucs[ts][\"Mean shift (A)\"] = np.mean(euc)\n",
-    "        eucs[ts][\"Shift s.d. (A)\"] = np.std(euc)\n",
+    "    eucs = {}\n",
+    "    for ts in list(xf_files.keys()):\n",
+    "        with open(xf_files[ts], \"r\") as f:\n",
+    "            lines = f.readlines()\n",
+    "            euc = [(float(l.split()[4])**2 + float(l.split()[5])**2)**0.5 for l in lines]\n",
+    "            eucs[ts] = {}\n",
+    "            eucs[ts][\"Tilt series\"] = align_md[\"ts\"][ts]\n",
+    "            eucs[ts][\"Mean shift (A)\"] = np.mean(euc)\n",
+    "            eucs[ts][\"Shift s.d. (A)\"] = np.std(euc)\n",
     "\n",
-    "eucs_df = pd.DataFrame.from_dict(eucs, orient=\"index\")\n",
+    "    eucs_df = pd.DataFrame.from_dict(eucs, orient=\"index\")\n",
     "\n",
-    "eucs_df\n"
+    "    eucs_df\n",
+    "\n",
+    "else:\n",
+    "    print(f\"{align_mdout_yaml_file} file not found. Was IMOD align run?\")\n"
    ]
   },
   {
@@ -69,18 +73,19 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10,5))\n",
-    "ax = sns.barplot(data=eucs_df,\n",
-    "                 x=\"Tilt series\",\n",
-    "                 y=\"Mean shift (A)\",\n",
-    "                 color=\"cornflowerblue\"\n",
-    "                )\n",
+    "if os.path.isfile(align_mdout_yaml_file) is True:\n",
+    "    plt.figure(figsize=(10,5))\n",
+    "    ax = sns.barplot(data=eucs_df,\n",
+    "                    x=\"Tilt series\",\n",
+    "                    y=\"Mean shift (A)\",\n",
+    "                    color=\"cornflowerblue\"\n",
+    "                    )\n",
     "\n",
-    "ax.errorbar(x=eucs_df.index,\n",
-    "            y=eucs_df[\"Mean shift (A)\"],\n",
-    "            yerr=eucs_df[\"Shift s.d. (A)\"], fmt=\"none\", c=\"k\")\n",
+    "    ax.errorbar(x=eucs_df.index,\n",
+    "                y=eucs_df[\"Mean shift (A)\"],\n",
+    "                yerr=eucs_df[\"Shift s.d. (A)\"], fmt=\"none\", c=\"k\")\n",
     "\n",
-    "plt.gca().set_ylim(bottom=0)"
+    "    plt.gca().set_ylim(bottom=0)"
    ]
   },
   {
@@ -115,13 +120,17 @@
    "source": [
     "stats_yaml_file = f\"{proj_name}_imod_align_stats.yaml\"\n",
     "\n",
-    "with open(stats_yaml_file, \"r\") as f:\n",
-    "    stats = yaml.load(f.read(), Loader=yaml.FullLoader)\n",
-    "    \n",
-    "stats_df = pd.DataFrame.from_dict(stats).drop(columns=[\"index\"])\n",
-    "stats_df[\"Tilt series\"] = stats_df[\"Tilt series\"].astype(int, copy=False)\n",
-    "# pd.set_option(\"display.max_rows\", None)\n",
-    "display(stats_df)"
+    "if os.path.isfile(stats_yaml_file) is False:\n",
+    "    print(f\"The IMOD stats file {stats_yaml_file} was not found\")\n",
+    "\n",
+    "else:\n",
+    "    with open(stats_yaml_file, \"r\") as f:\n",
+    "        stats = yaml.load(f.read(), Loader=yaml.FullLoader)\n",
+    "        \n",
+    "    stats_df = pd.DataFrame.from_dict(stats).drop(columns=[\"index\"])\n",
+    "    stats_df[\"Tilt series\"] = stats_df[\"Tilt series\"].astype(int, copy=False)\n",
+    "    # pd.set_option(\"display.max_rows\", None)\n",
+    "    display(stats_df)"
    ]
   },
   {
@@ -139,18 +148,19 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10,5))\n",
-    "ax = sns.barplot(data=stats_df,\n",
-    "                 x=\"Tilt series\",\n",
-    "                 y=\"Error mean (nm)\",\n",
-    "                 color=\"cornflowerblue\"\n",
-    "                )\n",
+    "if os.path.isfile(stats_yaml_file) is True:\n",
+    "    plt.figure(figsize=(10,5))\n",
+    "    ax = sns.barplot(data=stats_df,\n",
+    "                    x=\"Tilt series\",\n",
+    "                    y=\"Error mean (nm)\",\n",
+    "                    color=\"cornflowerblue\"\n",
+    "                    )\n",
     "\n",
-    "ax.errorbar(x=stats_df.index,\n",
-    "            y=stats_df[\"Error mean (nm)\"],\n",
-    "            yerr=stats_df[\"Error SD (nm)\"], fmt=\"none\", c=\"k\")\n",
+    "    ax.errorbar(x=stats_df.index,\n",
+    "                y=stats_df[\"Error mean (nm)\"],\n",
+    "                yerr=stats_df[\"Error SD (nm)\"], fmt=\"none\", c=\"k\")\n",
     "\n",
-    "plt.gca().set_ylim(bottom=0)"
+    "    plt.gca().set_ylim(bottom=0)"
    ]
   }
  ],
@@ -171,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.10 (default, Jun 22 2022, 20:18:18) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {

--- a/src/ot2rec_report/templates/workflow_diagram.ipynb
+++ b/src/ot2rec_report/templates/workflow_diagram.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "# PROCESSES = [\"motioncor2\", \"ctffind\", \"ctfsim\", \"imod_align\", \"imod_recon\", \"aretomo_recon\", \"savu_recon\", \"rlf_deconv\"]\n",
-    "PROCESSES = [\"motioncor2\", \"ctffind\", \"ctfsim\", \"aretomo_align\", \"imod_align\", \"imod_recon\", \"aretomo_recon\", \"savu_recon\", \"rlf_deconv\"]\n"
+    "PROCESSES = [\"motioncor2\", \"ctffind\", \"ctfsim\", \"aretomo_align\", \"imod_align\", \"imod_recon\", \"aretomo_recon\", \"savu_recon\", \"rlf_deconv\", \"exclude_bad_tilts\"]\n"
    ]
   },
   {
@@ -88,15 +88,17 @@
     "        7: \"Reconstruction (AreTomo)\",\n",
     "        8: \"Reconstruction (Savu)\",\n",
     "        9: \"Deconvolution (RedLionfish)\",\n",
+    "        10: \"ExcludeBadTilts\"\n",
     "    }\n",
     "\n",
     "    o2r_flow = [\n",
-    "        (1, 2), (2, 3), (3, 9), (6, 9)  # CTFSim + RLF\n",
+    "        (1, 2), (2, 3), (3, 9), (6, 9), # CTFSim + RLF\n",
     "        (1, 4), (4, 7),                 # AreTomo align + recon\n",
     "        (1, 5), (5, 6),                 # IMOD align + recon\n",
     "        (5, 8),                         # IMOD align + Savu recon\n",
     "        (5, 7),                         # IMOD align + Aretomo recon\n",
-    "        (4, 8)                          # Aretomo align + Savu recon\n",
+    "        (4, 8),                         # Aretomo align + Savu recon\n",
+    "        (1, 10), (10, 4), (10, 5)       # Exclude bad tilts\n",
     "    ]\n",
     "    \n",
     "    proc_names = [proc_dict[i] for i in plist]\n",
@@ -154,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.10 (default, Jun 22 2022, 20:18:18) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
# Changes

- Added exclude bad tilts template notebook, and to processes
- Plots barplot counting number of excluded tilts
- Shows min and max percentiles accepted (input to `o2r.excludebadtilts`
- Shows table of removed tilt indices and tilt angles for each tilt series
- Fixes bug in the IMOD align notebook which ends report generation if imod.stats was not run with ot2rec. Note added to the report instead

# Known bug
- Workflow diagram doesn't show up nicely - will be fixed in new refactor of workflow_diagram generation