### PR TITLE
change version number to 0.1.0post1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ this_dir = Path(__file__).parent
 long_description = (this_dir / "README.md").read_text()
 
 setup(
-    version="0.1.0a",
+    version="0.1.0post1",
     name="ot2rec_report",
     description="Generate reports for Ot2Rec",
     long_description=long_description,


### PR DESCRIPTION
Accidentally tagged previous release as an alpha version, so it was released as pre-release and is not preferentially installed on pypi.