### PR TITLE
Pass args to main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ this_dir = Path(__file__).parent
 long_description = (this_dir / "README.md").read_text()
 
 setup(
-    version="0.1.0post1",
+    version="0.1.0post2",
     name="ot2rec_report",
     description="Generate reports for Ot2Rec",
     long_description=long_description,

--- a/src/ot2rec_report/main.py
+++ b/src/ot2rec_report/main.py
@@ -76,7 +76,7 @@ def read_ipynb(filename):
         return json.load(f)
 
 
-def main():
+def main(args=None):
     lookup_dict = {
         "workflow_diagram": read_ipynb("workflow_diagram.ipynb"),
         "motioncor2": read_ipynb("report_mc.ipynb"),
@@ -94,7 +94,8 @@ def main():
         "rlf_deconv": read_ipynb("report_rlf_deconv.ipynb"),
     }
 
-    args = get_args_o2r_report.show(run=True)
+    if args is None:
+        args = get_args_o2r_report.show(run=True)
 
     final_nb = dc(read_ipynb("report_main.ipynb"))
     node_list = [i.name for i in args.processes.value]


### PR DESCRIPTION
Allow args to be passed into main, so that main can be run programmatically without the magicgui popping up. 