### PR TITLE
0.1.0post3 xythumbnails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ this_dir = Path(__file__).parent
 long_description = (this_dir / "README.md").read_text()
 
 setup(
-    version="0.1.0post2",
+    version="0.1.0post3",
     name="ot2rec_report",
     description="Generate reports for Ot2Rec",
     long_description=long_description,

--- a/src/ot2rec_report/templates/report_aretomo_recon.ipynb
+++ b/src/ot2rec_report/templates/report_aretomo_recon.ipynb
@@ -131,6 +131,23 @@
     "        )\n",
     "        plt.title(titles[i])\n",
     "\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "def show_tomograms_as_grid(tomo_filenames: list):\n",
+    "    plt.figure(figsize=(10, 5))\n",
+    "    nrows = math.ceil(len(tomo_filenames) / 4)\n",
+    "\n",
+    "    for i, tomo in enumerate(tomo_filenames):\n",
+    "        plt.subplot(nrows, 3, i+1)\n",
+    "        with mrcfile.open(tomo) as mrc:\n",
+    "            plt.imshow(\n",
+    "                mrc.data, \n",
+    "                cmap=\"Greys_r\", \n",
+    "                # vmin=np.percentile(mrc.data.flatten(), 10),\n",
+    "                # vmax=np.percentile(mrc.data.flatten(), 90),\n",
+    "            )\n",
+    "            plt.title(os.path.basename(tomo))\n",
+    "\n",
     "    plt.tight_layout()"
    ]
   },
@@ -151,8 +168,10 @@
    "source": [
     "# Show thumbnails of the tomograms\n",
     "tomogram_filenames = get_aretomo_tomofilenames()\n",
-    "for tomogram in tomogram_filenames:\n",
-    "    show_tomogram(tomogram)"
+    "xy_filenames = [f\"{os.path.splitext(f)[0]}_projXY.mrc\" for f in tomogram_filenames]\n",
+    "show_tomograms_as_grid(xy_filenames)\n",
+    "\n",
+    "print(\"\\n\\n\\n\\n\\n\\n\") # empty lines to avoid bottom being cut off in slides mode"
    ]
   }
  ],

--- a/src/ot2rec_report/templates/report_aretomo_recon.ipynb
+++ b/src/ot2rec_report/templates/report_aretomo_recon.ipynb
@@ -44,6 +44,8 @@
     "            printmd(\n",
     "                f\"Reconstruction algorithm = {aretomo_params['AreTomo_recon']['recon_algo']}\"\n",
     "            )\n",
+    "            printmd(f\"Bin factor = {aretomo_params['AreTomo_setup']['output_binning']}\")\n",
+    "            printmd(f\"Darktol = {aretomo_params['AreTomo_setup']['dark_tol']}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"{aretomo_yaml} not found, cannot retrieve AreTomo setup parameters\")\n",
     "\n",

--- a/src/ot2rec_report/templates/report_main.ipynb
+++ b/src/ot2rec_report/templates/report_main.ipynb
@@ -40,6 +40,7 @@
     "import ot2rec_report\n",
     "from importlib.metadata import version\n",
     "import pkg_resources\n",
+    "import math\n",
     "\n",
     "plt.rcParams.update({\"figure.max_open_warning\": 0})"
    ]


### PR DESCRIPTION
AreTomo recon notebook now shows xy thumbnails as a grid rather than xy, yz, xz thumbnails in rows. Makes it easier to quickly look through dozens+ of tomograms